### PR TITLE
Allow filterable dropdown to accept custom inputs

### DIFF
--- a/gooey/gui/components/widgets/dropdown_filterable.py
+++ b/gooey/gui/components/widgets/dropdown_filterable.py
@@ -105,7 +105,7 @@ class FilterableDropdown(Dropdown):
         self.listbox.OnGetItem = self.OnGetItem
         # model is created here because the design of these widget
         # classes is broken.
-        self.model = FilterableDropdownModel(self._meta['choices'], self._options, listeners=[self.interpretState])
+        self.model = FilterableDropdownModel(self._options.get('choices', []) or self._meta['choices'], self._options, listeners=[self.interpretState])
         # overriding this to false removes it from tab behavior.
         # and keeps the tabbing at the top-level widget level
         self.listbox.AcceptsFocusFromKeyboard = lambda *args, **kwargs: False


### PR DESCRIPTION
`FilterableDropdown` widget can accept choices which are not strictly enforced. In order to do this, `choices` are input under gooey_options rather than as a kwarg to the `add_argument()` method.

**Example**

```
@Gooey()
def main():
    p = GooeyParser()
    p.add_argument('not_strictly_enforced',
                   widget='FilterableDropdown',
                   gooey_options={
                       'choices': ['apple', 'banana', 'carrot']})

    p.add_argument('strictly_enforced',
                   widget='FilterableDropdown',
                   choices=['apple', 'banana', 'carrot'])
    ...
```
Not sure if the same should be added to the simple Dropdown class or if it makes sense to leave that as strictly enforced only.